### PR TITLE
Added Cloudflare RTMPS endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,9 @@ COPY stunnel/fb.conf /etc/stunnel/conf.d/fb.conf
 #Instagram Stunnel Port 19351
 COPY stunnel/instagram.conf /etc/stunnel/conf.d/instagram.conf
 
+#Cloudflare Stunnel Port 19352
+COPY stunnel/cloudflare.conf /etc/stunnel/conf.d/cloudflare.conf
+
 #Youtube
 ENV YOUTUBE_URL rtmp://a.rtmp.youtube.com/live2/
 ENV YOUTUBE_KEY ""
@@ -76,6 +79,10 @@ ENV FACEBOOK_KEY ""
 #Instagram
 ENV INSTAGRAM_URL rtmp://127.0.0.1:19351/rtmp/
 ENV INSTAGRAM_KEY ""
+
+#Cloudflare
+ENV CLOUDFLARE_URL rtmp://127.0.0.1:19352/live/
+ENV CLOUDFLARE_KEY ""
 
 ENV DEBUG ""
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ docker run -it -p 1935:1935 --name nginx-rtmps thiagoeolima/nginx-rtmps
 docker run -it -p 1935:1935 -e FACEBOOK_KEY="<key>" -e YOUTUBE_KEY=<key> thiagoeolima/nginx-rtmps
 ```
 
+* Cloudflare:
+
+```bash
+docker run -it -p 1935:1935 -e CLOUDFLARE_KEY="<key>" thiagoeolima/nginx-rtmps
+```
+
 * OBS
 
 ```bash
@@ -110,6 +116,7 @@ rtmp {
             record off;
 	    #push rtmp://a.rtmp.youtube.com/live2/<key>;
 	    #push rtmp://127.0.0.1:19350/rtmp/<key>;
+	    #push rtmp://127.0.0.1:19352/live/<key>;
         }
         
         application instagram {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,6 +30,14 @@ else
 	sed -i 's|#instagram| |g' $NGINX_TEMPLATE
 fi
 
+if [ -n "${CLOUDFLARE_KEY}" ]; then
+	echo "Cloudflare activate."
+	sed -i 's|#cloudflare|push '"$CLOUDFLARE_URL"'${CLOUDFLARE_KEY};|g' $NGINX_TEMPLATE
+	ENV_OK=1
+else 
+	sed -i 's|#cloudflare| |g' $NGINX_TEMPLATE
+fi
+
 if [ $ENV_OK -eq 1 ]; then
     envsubst < $NGINX_TEMPLATE > $NGINX_CONF
 else 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,6 +13,7 @@ rtmp {
             record off;
 	    #push rtmp://a.rtmp.youtube.com/live2/<key>;
 	    #push rtmp://127.0.0.1:19350/rtmp/<key>;
+	    #push rtmp://127.0.0.1:19352/live/<key>;
         }
         
         application instagram {

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -13,6 +13,7 @@ rtmp {
             record off;
             #facebook
             #youtube
+            #cloudflare
         }
         
         application instagram {

--- a/stunnel/cloudflare.conf
+++ b/stunnel/cloudflare.conf
@@ -1,0 +1,4 @@
+[cloudflare-live]
+client=yes
+accept=127.0.0.1:19352
+connect=live.cloudflare.com:443


### PR DESCRIPTION
Cloudflare requires RTMPS through their Stream service. I added a configuration to send RTMPS to Cloudflare's live.cloudflare.com endpoint.

I'm running this on my current configuration to stream from Haivision Makito Xs to Cloudflare:

Haivision Makito X (RTMP) -> NGINX-RTMPS -> Cloudflare